### PR TITLE
feat(pricing): add 华为云 Token Plan (智果园) — closes #160

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,13 @@ output/playwright/
 output/tmp/
 temp/
 .playwright-mcp/
+
+# Tooling / agent workspace (not part of source)
+.claude/commands/
+.claude/skills/
+.codegraph/
+.gitnexus/
+.opencode/
+.roo/
+.translation-cache/
+openspec/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+- feat(pricing): 新增华为云 Token Plan（智果园）到大陆套餐看板，4 个档位 ¥59 / ¥149 / ¥399 / ¥799
+
 ## [0.11.11] - 2026-06-16
 - feat(config): 新增 coding-plans.autoRefreshModels 配置项
 

--- a/assets/provider-pricing.json
+++ b/assets/provider-pricing.json
@@ -481,6 +481,75 @@
       ]
     },
     {
+      "provider": "huawei-token-plan",
+      "sourceUrls": [
+        "https://www.huaweicloud.com/agentorchard/tokenplan.html",
+        "https://console.huaweicloud.com/modelarts/?region=cn-southwest-2#/model-studio/resourcePlanManagement"
+      ],
+      "plans": [
+        {
+          "name": "Token Plan Lite",
+          "currentPrice": 59,
+          "currentPriceText": "¥59/月",
+          "originalPrice": null,
+          "originalPriceText": null,
+          "unit": "月",
+          "notes": "新手尝鲜，入门首选",
+          "serviceDetails": [
+            "用量限制: 每订阅月 5,000 万 Tokens",
+            "支持模型: GLM 全系、Kimi 全系、DeepSeek 全系",
+            "适配工具: OpenClaw、Claude Code、Cline、Cursor",
+            "购买限制: 个人版，限购 1 套，不支持退订"
+          ]
+        },
+        {
+          "name": "Token Plan Standard",
+          "currentPrice": 149,
+          "currentPriceText": "¥149/月",
+          "originalPrice": null,
+          "originalPriceText": null,
+          "unit": "月",
+          "notes": "日常使用，高性价比（官方标注\"最受欢迎\"）",
+          "serviceDetails": [
+            "用量限制: 每订阅月 1.3 亿 Tokens",
+            "支持模型: GLM 全系、Kimi 全系、DeepSeek 全系",
+            "适配工具: OpenClaw、Claude Code、Cline、Cursor",
+            "购买限制: 个人版，限购 1 套，不支持退订"
+          ]
+        },
+        {
+          "name": "Token Plan Pro",
+          "currentPrice": 399,
+          "currentPriceText": "¥399/月",
+          "originalPrice": null,
+          "originalPriceText": null,
+          "unit": "月",
+          "notes": "高频 AI 开发，Token 配额大幅提升",
+          "serviceDetails": [
+            "用量限制: 每订阅月 3.8 亿 Tokens",
+            "支持模型: GLM 全系、Kimi 全系、DeepSeek 全系",
+            "适配工具: OpenClaw、Claude Code、Cline、Cursor",
+            "购买限制: 个人版，限购 1 套，不支持退订"
+          ]
+        },
+        {
+          "name": "Token Plan Max",
+          "currentPrice": 799,
+          "currentPriceText": "¥799/月",
+          "originalPrice": null,
+          "originalPriceText": null,
+          "unit": "月",
+          "notes": "更多额度加持，重度 AI 开发首选",
+          "serviceDetails": [
+            "用量限制: 每订阅月 8.8 亿 Tokens",
+            "支持模型: GLM 全系、Kimi 全系、DeepSeek 全系",
+            "适配工具: OpenClaw、Claude Code、Cline、Cursor",
+            "购买限制: 个人版，限购 1 套，不支持退订"
+          ]
+        }
+      ]
+    },
+    {
       "provider": "infini-ai",
       "sourceUrls": [
         "https://cloud.infini-ai.com/platform/ai",
@@ -1573,7 +1642,5 @@
       ]
     }
   ],
-  "failures": [
-    "stepfun-step-plan: page.waitForFunction: Timeout 12000ms exceeded."
-  ]
+  "failures": []
 }

--- a/pages/app.js
+++ b/pages/app.js
@@ -13,6 +13,7 @@ const PROVIDER_LABELS = {
   'baidu-qianfan-ai': '百度智能云千帆',
   'tencent-cloud-ai': '腾讯云 Coding Plan',
   'tencent-cloud-token-plan': '腾讯云 Token Plan',
+  'huawei-token-plan': '华为云 Token Plan',
   'jdcloud-ai': '京东云 Coding Plan',
   'kwaikat-ai': '快手 KwaiKAT',
   'x-aio': 'X-AIO',
@@ -56,6 +57,8 @@ const PROVIDER_BUY_URLS = {
   'baidu-qianfan-ai': 'https://cloud.baidu.com/product/codingplan.html',
   'tencent-cloud-ai': 'https://buy.cloud.tencent.com/hunyuan',
   'tencent-cloud-token-plan': 'https://cloud.tencent.com/act/pro/tokenplan',
+  'huawei-token-plan':
+    'https://console.huaweicloud.com/modelarts/?region=cn-southwest-2#/model-studio/resourcePlanManagement',
   'jdcloud-ai': 'https://www.jdcloud.com/cn/pages/codingplan',
   'kwaikat-ai': 'https://www.streamlake.com/marketing/coding-plan',
   'x-aio': 'https://code.x-aio.com/',

--- a/scripts/fetch-provider-pricing.js
+++ b/scripts/fetch-provider-pricing.js
@@ -30,6 +30,7 @@ const PROVIDER_IDS = {
   OPENCODE: 'opencode',
   ROOCODE: 'roocode',
   GITHUB_COPILOT: 'github-copilot',
+  HUAWEI_TOKEN: 'huawei-token-plan',
   MTHREADS: 'mthreads-coding-plan',
   STEPFUN: 'stepfun-step-plan',
   CUCLOUD: 'cucloud-coding-plan',
@@ -3471,6 +3472,61 @@ async function parseTencentTokenPlans() {
   };
 }
 
+async function parseHuaweiTokenPlans() {
+  const pageUrl = 'https://www.huaweicloud.com/agentorchard/tokenplan.html';
+  const consoleUrl =
+    'https://console.huaweicloud.com/modelarts/?region=cn-southwest-2#/model-studio/resourcePlanManagement';
+
+  // Huawei Cloud 智果园 (AgentOrchard / ModelArts) Token Plan pricing from official documentation
+  // Source: https://www.huaweicloud.com/agentorchard/tokenplan.html
+  // Page renders client-side via JS obfuscation; data hardcoded from official published table.
+  const sharedModels = '支持模型: GLM 全系、Kimi 全系、DeepSeek 全系';
+  const sharedTools = '适配工具: OpenClaw、Claude Code、Cline、Cursor';
+  const sharedRestrictions = '购买限制: 个人版，限购 1 套，不支持退订';
+
+  const plans = [
+    asPlan({
+      name: 'Token Plan Lite',
+      currentPriceText: '¥59/月',
+      currentPrice: 59,
+      unit: '月',
+      notes: '新手尝鲜，入门首选',
+      serviceDetails: ['用量限制: 每订阅月 5,000 万 Tokens', sharedModels, sharedTools, sharedRestrictions],
+    }),
+    asPlan({
+      name: 'Token Plan Standard',
+      currentPriceText: '¥149/月',
+      currentPrice: 149,
+      unit: '月',
+      notes: '日常使用，高性价比（官方标注"最受欢迎"）',
+      serviceDetails: ['用量限制: 每订阅月 1.3 亿 Tokens', sharedModels, sharedTools, sharedRestrictions],
+    }),
+    asPlan({
+      name: 'Token Plan Pro',
+      currentPriceText: '¥399/月',
+      currentPrice: 399,
+      unit: '月',
+      notes: '高频 AI 开发，Token 配额大幅提升',
+      serviceDetails: ['用量限制: 每订阅月 3.8 亿 Tokens', sharedModels, sharedTools, sharedRestrictions],
+    }),
+    asPlan({
+      name: 'Token Plan Max',
+      currentPriceText: '¥799/月',
+      currentPrice: 799,
+      unit: '月',
+      notes: '更多额度加持，重度 AI 开发首选',
+      serviceDetails: ['用量限制: 每订阅月 8.8 亿 Tokens', sharedModels, sharedTools, sharedRestrictions],
+    }),
+  ];
+
+  return {
+    provider: PROVIDER_IDS.HUAWEI_TOKEN,
+    sourceUrls: unique([pageUrl, consoleUrl]),
+    fetchedAt: new Date().toISOString(),
+    plans: dedupePlans(plans),
+  };
+}
+
 async function parseXiaomiMimoTokenPlans() {
   const pageUrl = 'https://mimo.xiaomi.com';
   const newsUrl = 'https://www.ithome.com/0/935/666.htm';
@@ -4146,6 +4202,7 @@ async function main() {
     { provider: PROVIDER_IDS.XIAOMI, fn: parseXiaomiMimoTokenPlans },
     { provider: PROVIDER_IDS.OPENCODE, fn: parseOpenCodePlans },
     { provider: PROVIDER_IDS.GITHUB_COPILOT, fn: parseGithubCopilotPlans },
+    { provider: PROVIDER_IDS.HUAWEI_TOKEN, fn: parseHuaweiTokenPlans },
     { provider: PROVIDER_IDS.MTHREADS, fn: parseMthreadsCodingPlans },
     { provider: PROVIDER_IDS.STEPFUN, fn: parseStepfunStepPlans },
     { provider: PROVIDER_IDS.CUCLOUD, fn: parseCucloudCodingPlans },
@@ -4237,6 +4294,7 @@ module.exports = {
   parseInfiniCodingPlansFromDocsText,
   parseInfiniServiceDetailsByTier,
   parseAliyunTokenPlansFromDocsHtml,
+  parseHuaweiTokenPlans,
   parseCompshareCodingPlansFromHtml,
   parseKimiDomesticMembershipPlansFromText,
   parseJdCloudCodingPlansFromDocsText,

--- a/tests/pages/github-pages.spec.ts
+++ b/tests/pages/github-pages.spec.ts
@@ -102,6 +102,23 @@ test('大陆套餐展示阿里云 Token Plan', async ({ page }) => {
   );
 });
 
+test('大陆套餐展示华为云 Token Plan', async ({ page }) => {
+  await page.goto('/#domestic');
+  await waitForDomesticCards(page);
+
+  const card = page.locator('#provider-card-huawei-token-plan');
+  await expect(card).toBeVisible();
+  await expect(card.getByRole('heading', { name: '华为云 Token Plan' })).toBeVisible();
+  await expect(card.getByRole('heading', { name: 'Token Plan Lite' })).toBeVisible();
+  await expect(card.getByRole('heading', { name: 'Token Plan Standard' })).toBeVisible();
+  await expect(card.getByRole('heading', { name: 'Token Plan Pro' })).toBeVisible();
+  await expect(card.getByRole('heading', { name: 'Token Plan Max' })).toBeVisible();
+  await expect(card.getByRole('link', { name: '前往了解' })).toHaveAttribute(
+    'href',
+    'https://console.huaweicloud.com/modelarts/?region=cn-southwest-2#/model-studio/resourcePlanManagement',
+  );
+});
+
 test('抓取失败的 provider 不渲染套餐卡片', async ({ page }) => {
   await page.route('**/provider-pricing.json', async (route) => {
     await route.fulfill({

--- a/tests/scripts/fetch-provider-pricing.test.js
+++ b/tests/scripts/fetch-provider-pricing.test.js
@@ -13,6 +13,7 @@ const {
   parseInfiniPlanFromBundle,
   parseInfiniServiceDetailsByTier,
   parseAliyunTokenPlansFromDocsHtml,
+  parseHuaweiTokenPlans,
   parseCompshareCodingPlansFromHtml,
   parseKimiDomesticMembershipPlansFromText,
   parseJdCloudCodingPlansFromDocsText,
@@ -540,4 +541,33 @@ test('parseAliyunTokenPlansFromDocsHtml reads team seat and shared credit packag
   assert.match(result.plans[0].serviceDetails.join('\n'), /25,000 Credits\/坐席\/月/);
   assert.match(result.plans[0].serviceDetails.join('\n'), /qwen3\.6-plus/);
   assert.match(result.plans[3].serviceDetails.join('\n'), /625,000 Credits\/个/);
+});
+
+test('parseHuaweiTokenPlans returns the four 华为云 Token Plan tiers', async () => {
+  const result = await parseHuaweiTokenPlans();
+
+  assert.equal(result.provider, 'huawei-token-plan');
+  assert.deepEqual(
+    result.sourceUrls,
+    [
+      'https://www.huaweicloud.com/agentorchard/tokenplan.html',
+      'https://console.huaweicloud.com/modelarts/?region=cn-southwest-2#/model-studio/resourcePlanManagement',
+    ],
+  );
+  assert.deepEqual(
+    result.plans.map((plan) => ({ name: plan.name, currentPrice: plan.currentPrice, unit: plan.unit })),
+    [
+      { name: 'Token Plan Lite', currentPrice: 59, unit: '月' },
+      { name: 'Token Plan Standard', currentPrice: 149, unit: '月' },
+      { name: 'Token Plan Pro', currentPrice: 399, unit: '月' },
+      { name: 'Token Plan Max', currentPrice: 799, unit: '月' },
+    ],
+  );
+  const allDetails = result.plans.map((p) => p.serviceDetails.join('\n')).join('\n');
+  assert.match(allDetails, /GLM 全系/);
+  assert.match(allDetails, /Kimi 全系/);
+  assert.match(allDetails, /DeepSeek 全系/);
+  assert.match(allDetails, /OpenClaw、Claude Code、Cline、Cursor/);
+  assert.match(allDetails, /限购 1 套/);
+  assert.match(result.plans[3].serviceDetails.join('\n'), /8\.8 亿 Tokens/);
 });


### PR DESCRIPTION
## Summary
Adds the **华为云 Token Plan (智果园 / AgentOrchard / ModelArts)** to the domestic dashboard.

4 tiers (个人版, 限购 1 套, 不支持退订):

| Tier | Price | Tokens/month |
|---|---|---|
| Lite | ¥59 | 5,000 万 |
| Standard | ¥149 | 1.3 亿 (官方"最受欢迎") |
| Pro | ¥399 | 3.8 亿 |
| Max | ¥799 | 8.8 亿 |

Models: GLM / Kimi / DeepSeek 全系  
Tools: OpenClaw、Claude Code、Cline、Cursor

## Why hardcoded (not Playwright-parsed)
The pricing page returns a JS-obfuscation shell (~29KB) with no static pricing markup — real data is rendered client-side. Tried `curl` with browser headers, root URL, and a JS-decode sweep; nothing stable to extract.

Followed the **Tencent Token Plan pattern** (`parseTencentTokenPlans`) which is the project's precedent for stable, JS-rendered pricing pages. Trade-off documented inline; revisit with Playwright if/when Huawei ships an SSR fallback.

Source verified against issue #160 data (¥59 / ¥149 / ¥399 / ¥799 with exact quotas).

## Changes
- `scripts/fetch-provider-pricing.js` — `PROVIDER_IDS.HUAWEI_TOKEN`, `parseHuaweiTokenPlans()`, tasks entry, module export (+58)
- `tests/scripts/fetch-provider-pricing.test.js` — schema + 4-tier test (+30)
- `pages/app.js` — `PROVIDER_LABELS` + `PROVIDER_BUY_URLS` (+3)
- `tests/pages/github-pages.spec.ts` — Playwright card render test (+17)
- `CHANGELOG.md` — Unreleased entry (+3)
- `assets/provider-pricing.json` — regenerated via `npm run pricing:fetch` (+135)

Plus a separate `chore: repo hygiene` commit:
- `.gitignore`: ignore agent/tooling dirs (`.claude/`, `.codegraph/`, `.gitnexus/`, `.opencode/`, `.roo/`, `.translation-cache/`, `openspec/`)
- `AGENTS.md`: append GitNexus MCP block
- `package-lock.json`: sync version field

## Verification
- `npm run typecheck` — clean
- `node --test tests/scripts/fetch-provider-pricing.test.js` — **15/15 pass** (including new Huawei test)
- `npm run pricing:fetch` — `huawei-token-plan: 4` plans emitted; JSON schema matches existing providers
- Playwright e2e (`test:pages`) — not run locally (browser binaries not installed); spec mirrors the Aliyun Token Plan test verbatim and should pass in CI

Closes #160